### PR TITLE
Add, remove, and fix links, descriptions, and spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This list aims to be a curated set of high quality educational resources. The av
 *(HTML, CSS, JavaScript, jQuery, Python, Ruby, Rails, PHP, C++, Java)*
 
 #### [Khan Academy's Hour of Code](https://www.khanacademy.org/hourofcode)
-**Free** Interactive one-hour courses to learn the very basics of web development.\
+**Free** interactive 1-hour courses to learn the very basics of web development\
 *(HTML, CSS, JavaScript, SQL)*
 
 #### [UpLeveled Bootcamp Prep Course](https://learn.upleveled.io/)

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ This list aims to be a curated set of high quality educational resources. The av
 *(SQL, database concepts)*
 
 #### [The Odin Project](https://www.theodinproject.com)
-**Free** Beginner to intermediate full-stack courses with Ruby and JS learning paths\
+**Free** beginner to intermediate full-stack courses with Ruby and JS learning paths\
 *(HTML, CSS, JavaScript, Ruby, Rails)*
 
 #### [GitHub Skills](https://github.com/skills)
-**Free** Self paced, interactive projects to learn Git and GitHub, created and maintained by GitHub's training team\
+**Free** self paced, interactive projects to learn Git and GitHub, created and maintained by GitHub's training team\
 *(Git, GitHub)*
 
 #### [Grid Garden](https://cssgridgarden.com/)
@@ -94,7 +94,7 @@ This list aims to be a curated set of high quality educational resources. The av
 ## Intermediate
 
 #### Khan Academy [Computer Programming](https://www.khanacademy.org/computing/computer-programming), [Computer Science](https://www.khanacademy.org/computing/computer-science)
-**Free** Intermediate to advanced courses on how to program drawings, animations, games, and webpages and more advanced computer science topics.\
+**Free** intermediate to advanced courses on how to program drawings, animations, games and webpages and more advanced computer science topics\
 *(HTML, CSS, JavaScript, SQL, algorithms, cryptography)*
 
 #### [Udacity](https://www.udacity.com/)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This list aims to be a curated set of high quality educational resources. The av
 *(CSS)*
 
 #### Udemy [Programming](https://www.udemy.com/courses/search/?q=programming), [Development](https://www.udemy.com/courses/Development/)
-**Freemium** marketplace of courses from third-party providers - quality may vary\
+**Freemium** marketplace of courses from third party providers - quality may vary\
 *(HTML, CSS, JavaScript, Ruby, Rails, Python, iOS, Android)*
 
 #### [Code Avengers](https://www.codeavengers.com/)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This list aims to be a curated set of high quality educational resources. The av
 ## Beginner
 
 #### [Codecademy](https://www.codecademy.com/)
-**Freemium** Interactive platform for learning to code in many different programming languages\
+**Freemium** platform for learning to code in many different programming languages\
 *(HTML, CSS, JavaScript, jQuery, Python, Ruby, Rails, PHP, C++, Java)*
 
 #### [Khan Academy's Hour of Code](https://www.khanacademy.org/hourofcode)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This list aims to be a curated set of high quality educational resources. The av
 *(HTML, CSS, JavaScript, Ruby, Rails)*
 
 #### [GitHub Skills](https://github.com/skills)
-**Free** Self paced, interactive projects to learn Git and GitHub. Created and maintained by GitHub's training team.\
+**Free** Self paced, interactive projects to learn Git and GitHub, created and maintained by GitHub's training team\
 *(Git, GitHub)*
 
 #### [Grid Garden](https://cssgridgarden.com/)
@@ -64,27 +64,31 @@ This list aims to be a curated set of high quality educational resources. The av
 *(CSS)*
 
 #### [Hexlet.io](https://en.hexlet.io)
-**Mixed** Self-paced, interactive projects to learn JavaScript, C, Regular Expressions, and computer science in general.  
+**Mixed** self paced, interactive projects to learn JavaScript, C, Regular Expressions and computer science in general\
 *(JavaScript, Regular Expressions, Bash, computer science, Ansible)*
 
 #### [Programming Historian](https://programminghistorian.org/en/lessons/)
-**Free** Peer-reviewed introductory courses for digital humanists.\
+**Free** peer reviewed introductory courses for digital humanists\
 *(Python, R, Unity, QGIS, HTML, Regular Expressions)*
 
 #### [Software Carpentry](https://software-carpentry.org/lessons/)
-**Free** Foundational coding and data science skills for researchers.\
+**Free** foundational coding and data science skills for researchers\
 *(Python, R, OpenRefine, Unix Shell, Git)*
 
-#### [Hyperskill by JetBrains Academy](https://hi.hyperskill.org/)
-**Freemium** Wide range of tracks in popular programming languages and development frameworks.\
+#### [Hyperskill by JetBrains Academy](https://hi.hyperskill.org)
+**Freemium** wide range of tracks in popular programming languages and development frameworks\
 *(Python, Java, Kotlin, SQL)*
 
+#### [Cratecode](https://cratecode.com/)
+**Free** online platform that teaches programming through interactive lessons\
+*(JavaScript, TypeScript, HTML, p5.js, Backend Web Development)*
+
 #### [DataCamp](https://www.datacamp.com/)
-**Freemium** Interactive platform for learning data science.\
+**Freemium** interactive platform for learning data science\
 *(Python, R, SQL, Power BI, ChatGPT)*
 
 #### [Developer Roadmaps](https://roadmap.sh/)
-**Free** A community effort to create roadmaps, guides, and other educational content to help guide developers in picking up a path.
+**Free** learning roadmap guides with links to educational content\
 *(Fullstack, UX Design, Cyber Security, Computer Science, Blockchain, DevOps, PostgreSQL)*
 
 ## Intermediate
@@ -106,7 +110,7 @@ This list aims to be a curated set of high quality educational resources. The av
 *(HTML, CSS, JavaScript, Ruby, Rails)*
 
 #### LinkedIn Learning: [Web Development](https://www.linkedin.com/learning/topics/web-development), [Web Design](https://www.linkedin.com/learning/topics/web-design)
-**Mixed** platform for video courses on web development and design\
+**Paid** platform for video courses on web development and design\
 *(HTML, CSS, JavaScript, web development, web design)*
 
 #### [Thinkful](https://www.thinkful.com/)
@@ -117,12 +121,16 @@ This list aims to be a curated set of high quality educational resources. The av
 **Free** crowdsourced mentorship platform of programming exercises and code reviews\
 *(Clojure, CoffeeScript, C++, C#, Elixir, Erlang, F#, Go, Haskell, JavaScript, Common Lisp, Lua, Objective-C, OCaml, Perl 5, PL/SQL, Python, Ruby, Scala, Swift)*
 
-#### [PluralSight](https://www.pluralsight.com)
-**Paid** platform for web development courses\
-*(JavaScript, AngularJS, Java)*
+#### [PluralSight](https://www.pluralsight.com/browse)
+**Paid** platform for courses in web development, software development, security and more\
+*(HTML, CSS, JavaScript, React, AngularJS, Java, SQL)*
 
-#### [CodeChef Problems](https://www.codechef.com)
-**Free** intermediate to advanced programming problems\
+#### [CodeChef Courses](https://www.codechef.com/learn)
+**Freemium** platform with courses in web development and software development\
+*(HTML, CSS, JavaScript, Python, Java, C++)*
+
+#### [CodeChef Problems](https://www.codechef.com/problems/easy/)
+**Freemium** intermediate to advanced programming problems\
 *(programming)*
 
 #### [CodingBat](https://codingbat.com/)
@@ -130,20 +138,24 @@ This list aims to be a curated set of high quality educational resources. The av
 *(Python, Java)*
 
 #### [Codewars](https://www.codewars.com/)
-**Free** code challenges. Compare your solution with those of others.\
+**Free** code challenges - compare your solution with those of others\
 *(JavaScript, CoffeeScript, Ruby, Python, Clojure, Haskell, Java)*
 
 #### [CodinGame](https://www.codingame.com/)
 **Free** Learn to code and game at the same time.\
 *(C#, C++, Java, JavaScript, Python, Bash, C, Clojure, Dart, F#, Go, Groovy, Haskell, Lua, ObjectiveC, Pascal, Perl, PHP, Ruby, Rust, Scala, Swift, VB.NET)*
 
+#### [1 Million Women To Tech Summer of Code](https://github.com/1millionwomentotech/toolkitten/tree/master/summer-of-code)
+**Free** programming course material for beginner, intermediate and advanced levels\
+*(Python, JavaScript, Data Science, artificial intelligence, machine learning, AR & VR)*
+
 #### [Wes Bos](https://wesbos.com/courses/)
 **Mixed** guided video courses to build products using new technologies\
 *(JavaScript, CSS, React, Node.js, GraphQL, Redux)*
 
-#### [Level Up Tutorials](https://levelup.video/)
-**Free** Cutting-edge, high-quality video tutorials for web developers and designers.\
-*(HTML, CSS, React, Svelte, JavaScript, Node JS, GraphQL, Typescript, Vue, Deno, GitHub, Gatsby, Figma, Ruby, Drupal, Magento, Wordpress)*
+#### [Level Up Tutorials](https://levelup.video/library)
+**Free** video tutorials for web developers and designers\
+*(HTML, CSS, JavaScript, React, Svelte, Vue, Node.js, GraphQL, TypeScript, Deno, GitHub, Figma, Ruby, Drupal, Magento, Wordpress)*
  
 ## Advanced
 
@@ -151,7 +163,7 @@ This list aims to be a curated set of high quality educational resources. The av
 **Free** courses from MIT on advanced computer science topics\
 *(varied and extensive computer science topics, C, C++, ..)*
 
-#### [EDX](https://www.edx.org/learn/computer-programming)
+#### [edX](https://www.edx.org/learn/computer-programming)
 **Free** courses from Harvard, MIT, and other universities\
 *(varied computer science subjects including theory and programming, data science, algorithms, ...)*
 
@@ -162,6 +174,10 @@ This list aims to be a curated set of high quality educational resources. The av
 #### [Awesome CS Courses](https://github.com/prakhar1989/awesome-courses/blob/master/README.md)
 **Free** university-level courses scoured from around the internet.\
 *(varied and extensive computer science topics, ...)*
+
+#### Metacademy [Roadmaps](https://metacademy.org/roadmaps/), [Course Guides](https://metacademy.org/course_guides/)
+**Free** graphs of interconnected topics required to master concepts\
+*(programming, machine learning)*
 
 #### [HackerRank](https://www.hackerrank.com/)
 **Free** programming challenges and contests\

--- a/README.md
+++ b/README.md
@@ -1,62 +1,50 @@
 # Learn to Program [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 #### Foundation in Web Development
 
-The Internet is filled with an ever-expanding number of courses, books and guides for programmers of all skill levels to improve their skills. Unfortunately, these resources are either hard to find or of low quality.
+The Internet is filled with an ever-expanding number of courses, books, and guides for programmers of all skill levels to improve their skills. Unfortunately, these resources are either hard to find or of low quality.
 
-This list aims to be a curated set of high quality educational resources. The availability of free content on the platform is highlighted along with the primary topics covered.
+This list aims to be a curated set of high-quality educational resources. The availability of free content on the platform is highlighted along with the primary topics covered.
 
 ## Beginner
 
 #### [Codecademy](https://www.codecademy.com/)
-**Free** platform for learning to code in web technologies\
-*(HTML, CSS, JavaScript, jQuery, Python, Ruby, Rails, PHP)*
+**Freemium** Interactive platform for learning to code in many different programming languages\
+*(HTML, CSS, JavaScript, jQuery, Python, Ruby, Rails, PHP, C++, Java)*
 
 #### [Khan Academy's Hour of Code](https://www.khanacademy.org/hourofcode)
-**Free** interactive 1-hour course to learn the very basics of web development\
+**Free** Interactive one-hour courses to learn the very basics of web development.\
 *(HTML, CSS, JavaScript, SQL)*
 
-#### [UpLeveled Bootcamp Prep Course](https://learn.upleveled.io/)
-**Freemium** platform for learning the basics of web development\
-*(HTML, CSS, JavaScript, Node.js, Git, GitHub)*
-
 #### [Treehouse](https://teamtreehouse.com/)
-**Paid** platform for courses how to build websites & apps\
+**Paid** Interactive online coding classes for at-home learning\
 *(Web Design, Front End Web Development, Rails, iOS, Android, PHP)*
 
-#### [Learn CSS Layout](https://learnlayout.com/)
-**Free** tutorial for how to do layout with CSS\
-*(CSS)*
-
 #### Udemy [Programming](https://www.udemy.com/courses/search/?q=programming), [Development](https://www.udemy.com/courses/Development/)
-**Freemium** marketplace of courses from third party providers. Quality may vary.\
+**Freemium** Marketplace of courses from third-party providers. Quality may vary.\
 *(HTML, CSS, JavaScript, Ruby, Rails, Python, iOS, Android)*
 
 #### [Code Avengers](https://www.codeavengers.com/)
-**Freemium** platform for basic web and app develoment courses\
+**Freemium** School-oriented learning platform for basic web and app development courses.\
 *(HTML, CSS, JavaScript)*
 
-#### [learn.shayhowe.com](https://learn.shayhowe.com/)
-**Free** beginner to intermediate guides on web development\
+#### [Shay Howe's Learn to Code HTML & CSS](https://learn.shayhowe.com/)
+**Free** Beginner to intermediate guides on web development.\
 *(HTML, CSS, JavaScript)*
 
 #### [HTML Dog](https://www.htmldog.com/)
-**Free** beginner and intermediate guides on web development\
+**Free** Beginner and intermediate guides on web development.\
 *(HTML, CSS, JavaScript)*
 
-#### Degreed [Web Development](https://degreed.com/learning/web%20development), [Programming](https://degreed.com/learning/programming)
-**Mixed** directory of courses, videos and other learning resources for web development and programming. Quality may vary.\
-*(HTML, CSS, JavaScript, AngularJS, Rails)*
+#### [freeCodeCamp](https://www.freecodecamp.org/)
+**Free** Learn to code. Build projects. Earn certifications. An open-source community of people who learn to code and help nonprofits.\
+*(HTML, CSS, JavaScript, Databases, Git & GitHub, Node.js, React.js, D3.js, Python)*
 
-#### [Free Code Camp](https://www.freecodecamp.org/)
-**Free** Learn to code and help nonprofits. An open source community of people who learn to code and help nonprofits.\
-*(HTML, CSS, JavaScript, Databases, Git & GitHub, Node.js, React.js, D3.js)*
+#### [The Odin Project](https://www.theodinproject.com)
+**Free** Beginner to intermediate full-stack curriculum with Ruby and JS learning paths.
+*(HTML, CSS, JavaScript, Ruby, Rails)*
 
-#### [Vertabelo Academy](https://academy.vertabelo.com/)
-**Free** SQL courses with interactive exercises and quizzes\
-*(SQL, database concepts)*
-
-#### [GitHub Learning Lab](https://lab.github.com/)
-**Free** Self paced, interactive projects to learn Git and GitHub. Created and maintained by GitHub's training team.\
+#### [GitHub Learning Lab](https://github.com/apps/github-learning-lab)
+**Free** Self-paced, interactive projects to learn Git and GitHub. Created and maintained by GitHub's training team.\
 *(Git, GitHub)*
 
 #### [Grid Garden](https://cssgridgarden.com/)
@@ -64,11 +52,11 @@ This list aims to be a curated set of high quality educational resources. The av
 *(CSS)*
 
 #### [Hexlet.io](https://en.hexlet.io)
-**Mixed** Self paced, interactive projects to learn JavaScript, C, Regular Expressions and computer science in general.  
+**Mixed** Self-paced, interactive projects to learn JavaScript, C, Regular Expressions, and computer science in general.  
 *(JavaScript, Regular Expressions, Bash, computer science, Ansible)*
 
 #### [Programming Historian](https://programminghistorian.org/en/lessons/)
-**Free** Peer reviewed introductory courses for digital humanists.\
+**Free** Peer-reviewed introductory courses for digital humanists.\
 *(Python, R, Unity, QGIS, HTML, Regular Expressions)*
 
 #### [Software Carpentry](https://software-carpentry.org/lessons/)
@@ -76,18 +64,22 @@ This list aims to be a curated set of high quality educational resources. The av
 *(Python, R, OpenRefine, Unix Shell, Git)*
 
 #### [Hyperskill by JetBrains Academy](https://hi.hyperskill.org/)
-**Free** teaches programming in Java by creating small applications built step by step\
-*(Java, OOP, Gradle, Maven, Spring Boot)*
+**Freemium** Wide range of tracks in popular programming languages and development frameworks.\
+*(Python, Java, Kotlin, SQL)*
 
-#### [Cratecode](https://cratecode.com/)
-**Free** online platform that teaches programming through interactive lessons\
-*(JavaScript, TypeScript, HTML, p5.js, Backend Web Development)*
+#### [DataCamp](https://www.datacamp.com/)
+**Freemium** Interactive platform for learning data science.\
+*(Python, R, SQL, Power BI, ChatGPT)*
+
+#### [Developer Roadmaps](https://roadmap.sh/)
+**Free** A community effort to create roadmaps, guides, and other educational content to help guide developers in picking up a path.
+*(Fullstack, UX Design, Cyber Security, Computer Science, Blockchain, DevOps, PostgreSQL)*
 
 ## Intermediate
 
 #### Khan Academy [Computer Programming](https://www.khanacademy.org/computing/computer-programming), [Computer Science](https://www.khanacademy.org/computing/computer-science)
-**Free** intermediate to advanced courses on how to program drawings, animations, games and webpages and more advanced computer science topics\
-*(HTML, CSS, JavaScript, algorithms, cryptography)*
+**Free** Intermediate to advanced courses on how to program drawings, animations, games, and webpages and more advanced computer science topics.\
+*(HTML, CSS, JavaScript, SQL, algorithms, cryptography)*
 
 #### [Udacity](https://www.udacity.com/)
 **Free** platform for computer science and web development courses\
@@ -102,7 +94,7 @@ This list aims to be a curated set of high quality educational resources. The av
 *(HTML, CSS, JavaScript, Ruby, Rails)*
 
 #### LinkedIn Learning: [Web Development](https://www.linkedin.com/learning/topics/web-development), [Web Design](https://www.linkedin.com/learning/topics/web-design)
-**Paid** platform for video courses on web development and design\
+**Mixed** platform for video courses on web development and design\
 *(HTML, CSS, JavaScript, web development, web design)*
 
 #### [Thinkful](https://www.thinkful.com/)
@@ -113,15 +105,11 @@ This list aims to be a curated set of high quality educational resources. The av
 **Free** crowdsourced mentorship platform of programming exercises and code reviews\
 *(Clojure, CoffeeScript, C++, C#, Elixir, Erlang, F#, Go, Haskell, JavaScript, Common Lisp, Lua, Objective-C, OCaml, Perl 5, PL/SQL, Python, Ruby, Scala, Swift)*
 
-#### [Stanford on iTunes U](https://itunes.stanford.edu/)
-**Free** programming and mobile development courses on iTunes from Stanford University\
-*(programming, startups, iOS)*
-
-#### [PluralSight](https://www.pluralsight.com/tag/developer?pageSize=48&sort=popular)
+#### [PluralSight](https://www.pluralsight.com)
 **Paid** platform for web development courses\
 *(JavaScript, AngularJS, Java)*
 
-#### [CodeChef Problems](https://www.codechef.com/problems/easy/)
+#### [CodeChef Problems](https://www.codechef.com)
 **Free** intermediate to advanced programming problems\
 *(programming)*
 
@@ -137,40 +125,31 @@ This list aims to be a curated set of high quality educational resources. The av
 **Free** Learn to code and game at the same time.\
 *(C#, C++, Java, JavaScript, Python, Bash, C, Clojure, Dart, F#, Go, Groovy, Haskell, Lua, ObjectiveC, Pascal, Perl, PHP, Ruby, Rust, Scala, Swift, VB.NET)*
 
-#### [1 Million Women To Tech Summer of Code](https://github.com/1millionwomentotech/toolkitten/tree/master/summer-of-code)
-**Free** programming course material for beginner, intermediate and advanced levels\
-*(Python, JavaScript, Data Science, artificial intelligence, machine learning, AR & VR)*
-
 #### [Wes Bos](https://wesbos.com/courses/)
 **Mixed** guided video courses to build products using new technologies\
 *(JavaScript, CSS, React, Node.js, GraphQL, Redux)*
+
+#### [Level Up Tutorials](https://levelup.video/)
+**Free** Cutting-edge, high-quality video tutorials for web developers and designers.\
+*(HTML, CSS, React, Svelte, JavaScript, Node JS, GraphQL, Typescript, Vue, Deno, GitHub, Gatsby, Figma, Ruby, Drupal, Magento, Wordpress)*
  
 ## Advanced
 
-
-#### [Paqmind](http://paqmind.com)
-**Free** Quiz your knowledge of programming\
-*(JavaScript, Node.js, React, functional programming)*
-
-#### [MIT Courseware](https://ocw.mit.edu/courses/find-by-topic/#cat=engineering&subcat=computerscience)
+#### [MIT OpenCourseWare](https://ocw.mit.edu/search/?t=Computer%20Science)
 **Free** courses from MIT on advanced computer science topics\
 *(varied and extensive computer science topics, C, C++, ..)*
 
-#### [EDX](https://www.edx.org/course/subject/computer-science)
+#### [EDX](https://www.edx.org/learn/computer-programming)
 **Free** courses from Harvard, MIT, and other universities\
 *(varied computer science subjects including theory and programming, data science, algorithms, ...)*
 
 #### [Coursera](https://www.coursera.org/courses?categories=cs-ai,cs-programming,cs-systems,cs-theory,infotech)
-**Free** platform for courses from universities and organizations worldwide\
+**Mixed** platform for courses from universities and organizations worldwide\
 *(varied computer science subjects including theory and programming, data science, algorithms, ...)*
 
 #### [Awesome CS Courses](https://github.com/prakhar1989/awesome-courses/blob/master/README.md)
 **Free** university-level courses scoured from around the internet.\
 *(varied and extensive computer science topics, ...)*
-
-#### Metacademy [Roadmaps](https://metacademy.org/roadmaps/), [Course Guides](https://metacademy.org/course_guides/)
-**Free** graphs of interconnected topics required to master concepts\
-*(programming, machine learning)*
 
 #### [HackerRank](https://www.hackerrank.com/)
 **Free** programming challenges and contests\

--- a/README.md
+++ b/README.md
@@ -20,8 +20,12 @@ This list aims to be a curated set of high quality educational resources. The av
 *(HTML, CSS, JavaScript, Node.js, Git, GitHub)*
 
 #### [Treehouse](https://teamtreehouse.com/)
-**Paid** Interactive online coding classes for at-home learning\
+**Paid** platform for courses how to build websites & apps\
 *(Web Design, Front End Web Development, Rails, iOS, Android, PHP)*
+
+#### [Learn CSS Layout](https://learnlayout.com/)
+**Free** tutorial for how to do layout with CSS\
+*(CSS)*
 
 #### Udemy [Programming](https://www.udemy.com/courses/search/?q=programming), [Development](https://www.udemy.com/courses/Development/)
 **Freemium** Marketplace of courses from third-party providers. Quality may vary.\

--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ This list aims to be a curated set of high quality educational resources. The av
 *(CSS)*
 
 #### Udemy [Programming](https://www.udemy.com/courses/search/?q=programming), [Development](https://www.udemy.com/courses/Development/)
-**Freemium** Marketplace of courses from third-party providers. Quality may vary.\
+**Freemium** marketplace of courses from third-party providers - quality may vary\
 *(HTML, CSS, JavaScript, Ruby, Rails, Python, iOS, Android)*
 
 #### [Code Avengers](https://www.codeavengers.com/)
-**Freemium** School-oriented learning platform for basic web and app development courses.\
+**Freemium** platform for basic web and app development courses\
 *(HTML, CSS, JavaScript)*
 
 #### [Shay Howe's Learn to Code HTML & CSS](https://learn.shayhowe.com/)
-**Free** Beginner to intermediate guides on web development.\
+**Free** beginner to intermediate guides on web development\
 *(HTML, CSS, JavaScript)*
 
 #### [HTML Dog](https://www.htmldog.com/)

--- a/README.md
+++ b/README.md
@@ -40,19 +40,19 @@ This list aims to be a curated set of high quality educational resources. The av
 *(HTML, CSS, JavaScript)*
 
 #### [HTML Dog](https://www.htmldog.com/)
-**Free** Beginner and intermediate guides on web development.\
+**Free** beginner and intermediate guides on web development\
 *(HTML, CSS, JavaScript)*
 
 #### [freeCodeCamp](https://www.freecodecamp.org/)
-**Free** Learn to code. Build projects. Earn certifications. An open-source community of people who learn to code and help nonprofits.\
+**Free** learn to code and help nonprofits at the same time\
 *(HTML, CSS, JavaScript, Databases, Git & GitHub, Node.js, React.js, D3.js, Python)*
 
 #### [The Odin Project](https://www.theodinproject.com)
 **Free** Beginner to intermediate full-stack curriculum with Ruby and JS learning paths.
 *(HTML, CSS, JavaScript, Ruby, Rails)*
 
-#### [GitHub Learning Lab](https://github.com/apps/github-learning-lab)
-**Free** Self-paced, interactive projects to learn Git and GitHub. Created and maintained by GitHub's training team.\
+#### [GitHub Skills](https://github.com/skills)
+**Free** Self paced, interactive projects to learn Git and GitHub. Created and maintained by GitHub's training team.\
 *(Git, GitHub)*
 
 #### [Grid Garden](https://cssgridgarden.com/)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Learn to Program [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 #### Foundation in Web Development
 
-The Internet is filled with an ever-expanding number of courses, books, and guides for programmers of all skill levels to improve their skills. Unfortunately, these resources are either hard to find or of low quality.
+The Internet is filled with an ever-expanding number of courses, books and guides for programmers of all skill levels to improve their skills. Unfortunately, these resources are either hard to find or of low quality.
 
-This list aims to be a curated set of high-quality educational resources. The availability of free content on the platform is highlighted along with the primary topics covered.
+This list aims to be a curated set of high quality educational resources. The availability of free content on the platform is highlighted along with the primary topics covered.
 
 ## Beginner
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ This list aims to be a curated set of high-quality educational resources. The av
 **Free** Interactive one-hour courses to learn the very basics of web development.\
 *(HTML, CSS, JavaScript, SQL)*
 
+#### [UpLeveled Bootcamp Prep Course](https://learn.upleveled.io/)
+**Freemium** platform for learning the basics of web development\
+*(HTML, CSS, JavaScript, Node.js, Git, GitHub)*
+
 #### [Treehouse](https://teamtreehouse.com/)
 **Paid** Interactive online coding classes for at-home learning\
 *(Web Design, Front End Web Development, Rails, iOS, Android, PHP)*

--- a/README.md
+++ b/README.md
@@ -47,8 +47,12 @@ This list aims to be a curated set of high quality educational resources. The av
 **Free** learn to code and help nonprofits at the same time\
 *(HTML, CSS, JavaScript, Databases, Git & GitHub, Node.js, React.js, D3.js, Python)*
 
+#### [Vertabelo Academy](https://academy.vertabelo.com/)
+**Free** SQL courses with interactive exercises and quizzes\
+*(SQL, database concepts)*
+
 #### [The Odin Project](https://www.theodinproject.com)
-**Free** Beginner to intermediate full-stack curriculum with Ruby and JS learning paths.
+**Free** Beginner to intermediate full-stack courses with Ruby and JS learning paths\
 *(HTML, CSS, JavaScript, Ruby, Rails)*
 
 #### [GitHub Skills](https://github.com/skills)


### PR DESCRIPTION
Closes #59

Summary: updated links, descriptions, and some spelling inconsistencies.

### Removed
- Degreed: a learning ecosystem for businesses
- Vertabelo Academy: non-essential, see DataCamp instead
- learnlayout.com: non-essential/redundant
- Crate Code: non-essential/redundant
- itunes.stanford.edu: redirects to a list of non-programming-related podcasts
- github.com/1millionwomentotech/toolkitten: non-essential/redundant
- Paqmind: no longer maintained and does not own paqmind.com, see: https://github.com/Paqmind/platform
- Metacademy: redundant, see roadmap.sh

### Added
- The Odin Project: free full-stack curriculum and an open-source community.
- Level Up Tutorials: large library of high-quality web videos from the co-host of Syntax.fm
- DataCamp: one of, if not the best interactive platforms for learning data science
- Roadmap.sh: developer roadmaps for various career and skill paths.